### PR TITLE
Fix composer paths and lint script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "autoload": {
     "psr-4": {
-      "App\\": "src/"
+      "App\\": "./"
     }
   },
   "autoload-dev": {
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "phpunit",
-    "lint": "phpcs --standard=PSR12 src/"
+    "lint": "phpcs --standard=PSR12 ."
   },
   "minimum-stability": "dev",
   "prefer-stable": true


### PR DESCRIPTION
## Summary
- update composer autoload path to root
- lint PHP from project root
- add empty `tests` directory for PHPUnit

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863611c5e98832b951fa11d0dc198c4